### PR TITLE
feat: Update Content Security Policy to enhance security and allow Po…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,12 +5,12 @@ import type { NextConfig } from "next";
 // E2B sandbox URLs need to be allowed for preview functionality
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com https://*.razorpay.com https://accounts.google.com https://apis.google.com;
+  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com https://*.razorpay.com https://accounts.google.com https://apis.google.com https://vercel.live https://*.posthog.com https://us-assets.i.posthog.com;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
   img-src 'self' blob: data: https://*.googleusercontent.com https://avatars.githubusercontent.com https://*.r2.dev https://*.e2b.dev https://*.e2b.app;
   font-src 'self' https://fonts.gstatic.com;
-  connect-src 'self' https://*.e2b.dev https://*.e2b.app wss://*.e2b.dev wss://*.e2b.app https://api.resend.com https://api.razorpay.com https://*.razorpay.com https://accounts.google.com https://api.github.com https://*.openai.com https://*.anthropic.com https://*.google.com https://generativelanguage.googleapis.com;
-  frame-src 'self' https://*.e2b.dev https://*.e2b.app https://checkout.razorpay.com https://api.razorpay.com https://accounts.google.com;
+  connect-src 'self' https://*.e2b.dev https://*.e2b.app wss://*.e2b.dev wss://*.e2b.app https://api.resend.com https://api.razorpay.com https://*.razorpay.com https://accounts.google.com https://api.github.com https://*.openai.com https://*.anthropic.com https://*.google.com https://generativelanguage.googleapis.com https://*.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com;
+  frame-src 'self' https://*.e2b.dev https://*.e2b.app https://checkout.razorpay.com https://api.razorpay.com https://accounts.google.com https://vercel.live;
   frame-ancestors 'none';
   form-action 'self';
   base-uri 'self';


### PR DESCRIPTION
…stHog integration
This pull request updates the Content Security Policy (CSP) configuration in `next.config.ts` to allow additional third-party services required for analytics and preview functionality. The most important changes are the inclusion of PostHog and Vercel Live domains in the relevant CSP directives.

Content Security Policy updates:

* Added `https://vercel.live`, `https://*.posthog.com`, and `https://us-assets.i.posthog.com` to the `script-src` directive to enable scripts from these sources.
* Included `https://*.posthog.com`, `https://us.i.posthog.com`, and `https://us-assets.i.posthog.com` in the `connect-src` directive for API and asset connections.
* Added `https://vercel.live` to the `frame-src` directive to allow framing from Vercel Live.