### PR TITLE
fix(release): move permissions section to the correct location in rel…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,15 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: 🎉 Release
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by moving the permissions block from the `release` job level to the top-level of the workflow file. This change ensures that the specified permissions apply to all jobs in the workflow, rather than just the `release` job.…ease workflow