### PR TITLE
fix: remove [skip ci] from auto-changeset to trigger releases

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -84,6 +84,5 @@ jobs:
           fi
           
           git add .changeset/
-          git commit -m "chore: auto-generate changeset [skip ci]"
-          git push
+          git commit -m "chore: auto-generate changeset"
           git push


### PR DESCRIPTION
This pull request makes a minor update to the auto-changeset workflow by removing the `[skip ci]` flag from the auto-generated changeset commit message. This ensures that CI will run on these commits in the future.